### PR TITLE
Make `kDrivingMotorPinionTeeth` an int

### DIFF
--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -62,7 +62,7 @@ constexpr bool kTurningEncoderInverted = true;
 // The MAXSwerve module can be configured with one of three pinion gears: 12T, 13T, or 14T.
 // This changes the drive speed of the module (a pinion gear with more teeth will result in a
 // robot that drives faster).
-constexpr double kDrivingMotorPinionTeeth = 14;
+constexpr int kDrivingMotorPinionTeeth = 14;
 
 // Calculations required for driving motor conversion factors and feed forward
 constexpr double kDrivingMotorFreeSpeedRps = 5676.0 / 60; // NEO free speed is 5676 RPM


### PR DESCRIPTION
Missed this change from the Java version of #5