### PR TITLE
Fixed writing incorrect current limit to steering motors

### DIFF
--- a/src/main/cpp/subsystems/MAXSwerveModule.cpp
+++ b/src/main/cpp/subsystems/MAXSwerveModule.cpp
@@ -72,7 +72,7 @@ MAXSwerveModule::MAXSwerveModule(const int drivingCANId, const int turningCANId,
   m_drivingSparkMax.SetIdleMode(kDrivingMotorIdleMode);
   m_turningSparkMax.SetIdleMode(kTurningMotorIdleMode);
   m_drivingSparkMax.SetSmartCurrentLimit(kDrivingMotorCurrentLimit.value());
-  m_turningSparkMax.SetSmartCurrentLimit(kDrivingMotorCurrentLimit.value());
+  m_turningSparkMax.SetSmartCurrentLimit(kTurningMotorCurrentLimit.value());
 
   // Save the SPARK MAX configurations. If a SPARK MAX browns out during
   // operation, it will maintain the above configurations.


### PR DESCRIPTION
I discovered that the incorrect current limit was getting written to the steering motor controllers. I also destroyed a NEO 550 along the way. 